### PR TITLE
DA-6 Skip Kitti Eval for dist training

### DIFF
--- a/tools/cfgs/kitti_models/pv_rcnn_ssl_60.yaml
+++ b/tools/cfgs/kitti_models/pv_rcnn_ssl_60.yaml
@@ -224,7 +224,7 @@ MODEL:
         OUTPUT_RAW_SCORE: False
 
         EVAL_METRIC: kitti
-
+        ENABLE_KITTI_EVAL: False
         NMS_CONFIG:
             MULTI_CLASSES_NMS: False
             NMS_TYPE: nms_gpu


### PR DESCRIPTION
Temporarily disable the Kitti eval metrics by a flag to continue training in dist mode.