### PR TITLE
New options to weight RCNN classification loss 

### DIFF
--- a/pcdet/models/roi_heads/roi_head_template.py
+++ b/pcdet/models/roi_heads/roi_head_template.py
@@ -509,7 +509,10 @@ class RoIHeadTemplate(nn.Module):
                 
                 # ----------- REG_VALID_MASK -----------
                 reg_fg_thresh = self.model_cfg.TARGET_CONFIG.UNLABELED_REG_FG_THRESH
-                filtering_mask = gt_iou_of_rois > reg_fg_thresh
+                if self.model_cfg.TARGET_CONFIG.get("UNLABELED_TEACHER_SCORES_FOR_RVM", False):
+                    filtering_mask = self.forward_ret_dict['rcnn_cls_score_teacher'][unlabeled_inds] > reg_fg_thresh
+                else:
+                    filtering_mask = gt_iou_of_rois > reg_fg_thresh
                 self.forward_ret_dict['reg_valid_mask'][unlabeled_inds] = filtering_mask.long()
 
                 # ----------- RCNN_CLS_LABELS -----------

--- a/pcdet/models/roi_heads/roi_head_template.py
+++ b/pcdet/models/roi_heads/roi_head_template.py
@@ -542,6 +542,10 @@ class RoIHeadTemplate(nn.Module):
                 unlabeled_rcnn_cls_weights[ul_interval_mask] = 0
             elif self.model_cfg['LOSS_CONFIG']['UL_RCNN_CLS_WEIGHT_TYPE'] == 'full-ema':
                 unlabeled_rcnn_cls_weights = rcnn_bg_score_teacher[unlabeled_inds]
+            # Use weights=teacher's BG scores on all except FGs(for FGs, weights=1)
+            elif self.model_cfg['LOSS_CONFIG']['UL_RCNN_CLS_WEIGHT_TYPE'] == 'uc-bg':           
+                ulb_fg_mask = self.forward_ret_dict['rcnn_cls_labels'][unlabeled_inds] == 1
+                unlabeled_rcnn_cls_weights[~ulb_fg_mask] = rcnn_bg_score_teacher[unlabeled_inds][~ulb_fg_mask]
             else:
                 raise ValueError
 

--- a/tools/cfgs/kitti_models/pv_rcnn_ssl_60.yaml
+++ b/tools/cfgs/kitti_models/pv_rcnn_ssl_60.yaml
@@ -211,6 +211,7 @@ MODEL:
             UNLABELED_SAMPLE_EASY_BG: False
             UNLABELED_SHARP_RCNN_CLS_LABELS: False
             UNLABELED_USE_CALIBRATED_IOUS: False
+            UNLABELED_TEACHER_SCORES_FOR_RVM: False
 
         LOSS_CONFIG:
             UL_RCNN_CLS_WEIGHT_TYPE: 'interval-only' # two options: `all` or `interval-only`

--- a/tools/cfgs/kitti_models/pv_rcnn_ssl_60.yaml
+++ b/tools/cfgs/kitti_models/pv_rcnn_ssl_60.yaml
@@ -210,6 +210,7 @@ MODEL:
             UNLABELED_SAMPLER_TYPE: None
             UNLABELED_SAMPLE_EASY_BG: False
             UNLABELED_SHARP_RCNN_CLS_LABELS: False
+            UNLABELED_USE_CALIBRATED_IOUS: False
 
         LOSS_CONFIG:
             UL_RCNN_CLS_WEIGHT_TYPE: 'interval-only' # two options: `all` or `interval-only`


### PR DESCRIPTION
- Added new weighing types (`uc-bg` and `fc-uc-bg`) for RCNN classification loss weights
- Bugfix for `reg_valid_mask` (earlier it was being set based on `rcnn_cls_labels` due to which there were some contradictions in masking `reg_valid_mask`)
- Added new option to mask `reg_valid_mask` based on teacher's confidence scores (`rcnn_cls_score_teacher`)