### PR TITLE
FG classification threshold for labeled data like unlabeled data

### DIFF
--- a/pcdet/models/roi_heads/target_assigner/proposal_target_layer.py
+++ b/pcdet/models/roi_heads/target_assigner/proposal_target_layer.py
@@ -168,7 +168,7 @@ class ProposalTargetLayer(nn.Module):
         iou_bg_thresh = self.roi_sampler_cfg.CLS_BG_THRESH
         # NOTE (shashank): Use classwise local thresholds used in unlabeled ROIs for labeled ROIs  
         if self.roi_sampler_cfg.USE_ULB_CLS_FG_THRESH_FOR_LB :
-            iou_fg_thresh = self.roi_sampler_cfg.UNLABELED_REG_FG_THRESH
+            iou_fg_thresh = self.roi_sampler_cfg.UNLABELED_CLS_FG_THRESH
             iou_fg_thresh = roi_ious.new_tensor(iou_fg_thresh).unsqueeze(0).repeat(len(roi_ious), 1)
             iou_fg_thresh = torch.gather(iou_fg_thresh, dim=-1, index=(cur_roi_labels[sampled_inds]-1).unsqueeze(-1)).squeeze(-1)
         else:


### PR DESCRIPTION
This PR adds an option to use same class-wise FG classification thresholds used for unlabeled samples (`UNLABELED_CLS_FG_THRESH`) in labeled samples as well. 
`USE_ULB_CLS_FG_THRESH_FOR_LB=True` enables this option else the default threshold would be used for labeled samples i.e. `CLS_FG_THRESH=0.55`
